### PR TITLE
Panorama: Fix bugs on map init

### DIFF
--- a/src/game_map.cpp
+++ b/src/game_map.cpp
@@ -137,10 +137,8 @@ void Game_Map::Setup(std::unique_ptr<lcf::rpg::Map> map_in) {
 	map = std::move(map_in);
 
 	SetupCommon();
-	panorama_on_map_init = true;
-	reset_panorama_x_on_next_init = true;
-	reset_panorama_y_on_next_init = true;
 
+	panorama_on_map_init = true;
 	Parallax::ClearChangedBG();
 
 	SetEncounterRate(GetMapInfo().encounter_steps);
@@ -1643,11 +1641,6 @@ void Game_Map::Parallax::Initialize(int width, int height) {
 
 	Params params = GetParallaxParams();
 
-	if (panorama_on_map_init) {
-		AddPositionX(map_info.position_x);
-		AddPositionY(map_info.position_y);
-	}
-
 	if (reset_panorama_x_on_next_init) {
 		ResetPositionX();
 	}
@@ -1806,7 +1799,6 @@ void Game_Map::Parallax::ChangeBG(const Params& params) {
 	map_info.parallax_vert_auto = params.scroll_vert_auto;
 	map_info.parallax_vert_speed = params.scroll_vert_speed;
 
-	panorama_on_map_init = false;
 	reset_panorama_x_on_next_init = !Game_Map::LoopHorizontal() && !map_info.parallax_horz;
 	reset_panorama_y_on_next_init = !Game_Map::LoopVertical() && !map_info.parallax_vert;
 
@@ -1819,4 +1811,5 @@ void Game_Map::Parallax::ChangeBG(const Params& params) {
 void Game_Map::Parallax::ClearChangedBG() {
 	Params params {}; // default Param indicates no override
 	ChangeBG(params);
+	panorama_on_map_init = false;
 }

--- a/src/spriteset_map.cpp
+++ b/src/spriteset_map.cpp
@@ -142,6 +142,7 @@ void Spriteset_Map::ParallaxUpdated() {
 		panorama_name = name;
 		if (name.empty()) {
 			panorama->SetBitmap(BitmapRef());
+			Game_Map::Parallax::Initialize(0, 0);
 		}
 		else {
 			FileRequestAsync* request = AsyncHandler::RequestFile("Panorama", panorama_name);


### PR DESCRIPTION
That fixes the regression with the toilet room and with it the final known panorama bug.

- Panorama is now set to 0 when no panorama is set (regression introduced in a recent commit)
- reset_panorama were already set to true in ChangeBG when clearing
- panorama_on_map_init was cleared too early