### PR TITLE
Retry when fails to fetch necessary file

### DIFF
--- a/src/async_handler.cpp
+++ b/src/async_handler.cpp
@@ -82,6 +82,85 @@ namespace {
 		Output::Debug("DL Failure: {}", req->GetPath());
 		req->DownloadDone(false);
 	}
+
+	void async_wget(
+		const std::string& url,
+		const std::string& file,
+		const std::string& param,
+		FileRequestAsync* obj) {
+		emscripten_async_wget2(
+			url.c_str(),
+			file.c_str(),
+			"GET",
+			param.c_str(),
+			obj,
+			download_success,
+			download_failure,
+			nullptr);
+	}
+
+	constexpr size_t ASYNC_MAX_RETRY_COUNT = 1024;
+	struct async_parameter_pack {
+		std::string url;
+		std::string file;
+		std::string param;
+		FileRequestAsync* obj;
+		size_t count;
+
+		async_parameter_pack(
+			const std::string& _url,
+			const std::string& _file,
+			const std::string& _param,
+			FileRequestAsync* _obj) : url(_url), file(_file), param(_param), obj(_obj), count(0) {}
+	};
+
+	void download_success_retry(unsigned, void* userData, const char*) {
+		auto pack = static_cast<async_parameter_pack*>(userData);
+		//Output::Debug("DL Success: {}", req->GetPath());
+		pack->obj->DownloadDone(true);
+		delete pack;
+	}
+
+	void start_async_wget_with_retry(async_parameter_pack* pack);
+
+	void download_failure_retry(unsigned, void* userData, int) {
+		auto pack = static_cast<async_parameter_pack*>(userData);
+		++(pack->count);
+		if (pack->count >= ASYNC_MAX_RETRY_COUNT) {
+			Output::Debug("Max retries exceeded");
+			delete pack;
+			return;
+		}
+		Output::Debug("DL Failure: {}. Retrying for the {} time", pack->obj->GetPath(), pack->count);
+		// req->DownloadDone(false);
+
+		// Keep on retrying until success
+		start_async_wget_with_retry(pack);
+	}
+
+	void start_async_wget_with_retry(async_parameter_pack* pack) {
+		emscripten_async_wget2(
+			pack->url.c_str(),
+			pack->file.c_str(),
+			"GET",
+			pack->param.c_str(),
+			pack,
+			download_success_retry,
+			download_failure_retry,
+			nullptr);
+	}
+
+	void async_wget_with_retry(
+		std::string url,
+		std::string file,
+		std::string param,
+		FileRequestAsync* obj) {
+		// emscripten_async_wget2 does not accept modern c++ functions (such as lambdas)
+		// so we could only pass raw pointer to it
+		// the pack will be deleted when download succeeds
+		auto pack = new async_parameter_pack(url, file, param, obj);
+		start_async_wget_with_retry(pack);
+	}
 #endif
 }
 
@@ -273,15 +352,12 @@ void FileRequestAsync::Start() {
 	request_path = Utils::ReplaceAll(request_path, "#", "%23");
 	request_path = Utils::ReplaceAll(request_path, "+", "%2B");
 
-	emscripten_async_wget2(
-		request_path.c_str(),
-		(it != file_mapping.end() ? it->second : path).c_str(),
-		"GET",
-		NULL,
-		this,
-		download_success,
-		download_failure,
-		NULL);
+	auto request_file = (it != file_mapping.end() ? it->second : path);
+	if (IsNecessary()) {
+		async_wget_with_retry(request_path, request_file, "", this);
+	} else {
+		async_wget(request_path, request_file, "", this);
+	}
 #else
 #  ifdef EM_GAME_URL
 #    warning EM_GAME_URL set and not an Emscripten build!

--- a/src/async_handler.h
+++ b/src/async_handler.h
@@ -143,9 +143,23 @@ public:
 	 * When the graphic flag is set, Scene_Map will block starting any
 	 * user requested transitions until the request is finished.
 	 *
-	 * @param important value of important flag.
+	 * @param graphic value of graphic flag.
 	 */
 	void SetGraphicFile(bool graphic);
+
+	/**
+	 * @return If while has necessary flag.
+	 */
+	bool IsNecessary() const;
+
+	/**
+	 * Sets the necessary flag.
+	 * When set, that means the game will crash without this file.
+	 * FileRequestAsync will retry getting the file until success.
+	 *
+	 * @param necessary value of necessary flag.
+	 */
+	void SetNecessary(bool necessary);
 
 	/**
 	 * Starts the async requests.
@@ -209,6 +223,7 @@ private:
 	int state = State_DoneFailure;
 	bool important = false;
 	bool graphic = false;
+	bool necessary = true;
 };
 
 /**
@@ -245,9 +260,16 @@ inline bool FileRequestAsync::IsGraphicFile() const {
 	return graphic;
 }
 
+inline bool FileRequestAsync::IsNecessary() const {
+	return necessary;
+}
+
+inline void FileRequestAsync::SetNecessary(bool necessary) {
+	this->necessary = necessary;
+}
+
 inline const std::string& FileRequestAsync::GetPath() const {
 	return path;
 }
-
 
 #endif

--- a/src/scene_logo.cpp
+++ b/src/scene_logo.cpp
@@ -127,10 +127,12 @@ void Scene_Logo::OnIndexReady(FileRequestResult*) {
 	ini->SetImportantFile(true);
 	FileRequestAsync* exfont = AsyncHandler::RequestFile("ExFont");
 	exfont->SetImportantFile(true);
+	exfont->SetNecessary(false);
 	FileRequestAsync* soundfont = AsyncHandler::RequestFile("easyrpg.soundfont");
 	soundfont->SetImportantFile(true);
 	FileRequestAsync* autorun_ineluki = AsyncHandler::RequestFile("autorun.script");
 	autorun_ineluki->SetImportantFile(true);
+	autorun_ineluki->SetNecessary(false);
 
 	db->Start();
 	tree->Start();


### PR DESCRIPTION
I planned a tour to some far locations and the game crashed again for a broken GET request.
When a request fails, we can still retry, why should we give it up?