### PR TITLE
Update nickname size get to use new method

### DIFF
--- a/src/multiplayer/chatname.cpp
+++ b/src/multiplayer/chatname.cpp
@@ -60,7 +60,7 @@ void ChatName::Draw(Bitmap& dst) {
 			return;
 		}
 
-		auto rect = Font::NameText()->GetSize(nick_trim);
+		auto rect = Text::GetSize(Font::NameText(), nick_trim);
 		nick_img = Bitmap::Create(rect.width + 1, rect.height + 1, true);
 
 		BitmapRef sys;

--- a/src/multiplayer/chatname.cpp
+++ b/src/multiplayer/chatname.cpp
@@ -60,7 +60,7 @@ void ChatName::Draw(Bitmap& dst) {
 			return;
 		}
 
-		auto rect = Text::GetSize(Font::NameText(), nick_trim);
+		auto rect = Text::GetSize(*Font::NameText(), nick_trim);
 		nick_img = Bitmap::Create(rect.width + 1, rect.height + 1, true);
 
 		BitmapRef sys;


### PR DESCRIPTION
Seems that the EasyRPG codebase uses this function to get the size of a string now. `Text::GetSize()` can be found in many places for this purpose, and replaces areas that used to use `Font::GetSize()`.