### PR TITLE
Don't apply screen flash to players with repeating flashes

### DIFF
--- a/src/multiplayer/game_multiplayer.cpp
+++ b/src/multiplayer/game_multiplayer.cpp
@@ -740,6 +740,9 @@ void Game_Multiplayer::ApplyPlayerBattleAnimUpdates() {
 
 void Game_Multiplayer::ApplyFlash(int r, int g, int b, int power, int frames) {
 	for (auto& p : players) {
+		if (repeating_flashes.find(p.first) != repeating_flashes.end()) {
+			continue;
+		}
 		p.second.ch->Flash(r, g, b, power, frames);
 		p.second.chat_name->SetFlashFramesLeft(frames);
 	}


### PR DESCRIPTION
This replicates the pre- 9c203419af behavior where screen flashes
(`Scene_Map::UpdateStage1 → Game_Map::Update → Game_Screen::Update → … → Game_Screen::FlashOnce`)
would immediately get overwritten by repeating flashes
(`Scene_Map::UpdateStage1 → Scene_Map::UpdateGraphics → Spriteset_Map::Update`).

Fixes PlayerOther flickering in MAP2059 (Sunset Savannah, Yume 2kki) seen during the event triggered by using the Fairy effect.
 ([save file before triggering the event](https://github.com/user-attachments/files/21676954/Save03.lsd.zip))
More context: battle animations (such as the one in the event above) trigger a 0-frame screen flash on each frame. This doesn't actually cause the screen to flash but does cancel out any existing screen flash if there's one active.
