### PR TITLE
Draw player names below the screen layer

### DIFF
--- a/src/multiplayer/chatname.cpp
+++ b/src/multiplayer/chatname.cpp
@@ -13,7 +13,8 @@ std::map<std::string, std::array<int, 96>> sprite_y_offsets;
 ChatName::ChatName(int id, PlayerOther& player, std::string nickname)
 	:player(player),
 	nickname(std::move(nickname)),
-	Drawable(Priority_Screen + id) {
+	// names are drawn below picture overlays (Priority_Picture*) and screen flashes (Priority_Screen)
+	Drawable(Priority_Weather + id + 1) {
 	DrawableMgr::Register(this);
 }
 


### PR DESCRIPTION
Fixes an issue where a screen flash wouldn't cover the name of the other player if they had a repeating flash set.
[Test 2kki map (flash, picture overlay)](https://github.com/user-attachments/files/21690338/Map0229.lmu.zip)
