### PR TITLE
Don't make other players flash on screen flash

### DIFF
--- a/src/game_screen.cpp
+++ b/src/game_screen.cpp
@@ -119,8 +119,6 @@ void Game_Screen::FlashOnce(int r, int g, int b, int s, int frames) {
 	data.flash_time_left = frames;
 	data.flash_continuous = false;
 	flash_period = 0;
-
-	GMI().ApplyFlash(r, g, b, s, frames);
 }
 
 void Game_Screen::FlashBegin(int r, int g, int b, int s, int frames) {

--- a/src/multiplayer/game_multiplayer.cpp
+++ b/src/multiplayer/game_multiplayer.cpp
@@ -738,13 +738,6 @@ void Game_Multiplayer::ApplyPlayerBattleAnimUpdates() {
 	}
 }
 
-void Game_Multiplayer::ApplyFlash(int r, int g, int b, int power, int frames) {
-	for (auto& p : players) {
-		p.second.ch->Flash(r, g, b, power, frames);
-		p.second.chat_name->SetFlashFramesLeft(frames);
-	}
-}
-
 void Game_Multiplayer::ApplyRepeatingFlashes() {
 	for (auto& rf : repeating_flashes) {
 		if (players.find(rf.first) != players.end()) {

--- a/src/multiplayer/game_multiplayer.h
+++ b/src/multiplayer/game_multiplayer.h
@@ -42,7 +42,6 @@ public:
 	bool IsBattleAnimSynced(int anim_id);
 	void PlayerBattleAnimShown(int anim_id);
 	void ApplyPlayerBattleAnimUpdates();
-	void ApplyFlash(int r, int g, int b, int power, int frames);
 	void ApplyRepeatingFlashes();
 	void ApplyTone(Tone tone);
 	void ApplyScreenTone();


### PR DESCRIPTION
Alternative to #70, depends on #71. Once #71 gets merged player names will be implicitly affected by screen flashes just like player sprites, making explicit flashing redundant.