### PR TITLE
Send shown pictures on join

### DIFF
--- a/src/multiplayer/game_multiplayer.h
+++ b/src/multiplayer/game_multiplayer.h
@@ -125,6 +125,7 @@ public:
 	void SpawnOtherPlayer(int id);
 	void ResetRepeatingFlash();
 	void InitConnection();
+	void SendShownPictures();
 };
 
 inline Game_Multiplayer& GMI() { return Game_Multiplayer::Instance(); }


### PR DESCRIPTION
Fixes an issue where currently shown pictures would not reappear after reconnecting. A prominent example is player sprites in all FC Caverns areas (Yume 2kki) not being shown until the player changes effects. Entering FC Caverns currently triggers a reconnect which means the issue is fairly easy to encounter.

Small note about packet order: [`ri` is currently sent before `pns`][0], which means it's possible for the client to attempt to send shown pictures before it receives allowed picture names and prefixes. The only case I can think of when the client doesn't already have picture names from the previous join is during the initial game launch.

An alternative would be to send pictures when `pns` is received, that way the initial issue would be solved and the code wouldn't depend on when or in which order packets are sent. This is not done here because pictures can persist between map changes (RPG Maker 2003 1.12 and newer, `erase_on_map_change`). `Pns` packets are not resent during room changes and as such would cause the picture not to be displayed after changing maps. One example can be seen in [the EasyRPG test suite][1] (TestGame-2003, Image operations → third character from the right, red armor) with server `picture_prefixes` set to `"number"`. I could not find any examples of allowed persistent pictures in games currently hosted on YNO.

[0]: https://github.com/ynoproject/ynoserver/blob/53388b29437d92f59cbacfe1c1107354da4465b2/server/room.go#L134-L161
[1]: https://github.com/EasyRPG/TestGame/tree/978550540ebb348a000e576989e5b57d8c5904b5/TestGame-2003