### PR TITLE
Don't treat two different consecutive flashes as repeating

### DIFF
--- a/src/multiplayer/game_multiplayer.cpp
+++ b/src/multiplayer/game_multiplayer.cpp
@@ -112,9 +112,10 @@ static bool MovePlayerToPos(Game_PlayerOther& player, int x, int y) {
 }
 
 void Game_Multiplayer::ResetRepeatingFlash() {
+	repeating_flash_active = false;
 	frame_index = 0;
 	last_flash_frame_index = -1;
-	last_frame_flash.reset();
+	last_flash_frame_flash.fill(0);
 	repeating_flashes.clear();
 }
 
@@ -593,16 +594,16 @@ void Game_Multiplayer::MainPlayerFlashed(int r, int g, int b, int p, int f) {
 	std::array<int, 5> flash_array = std::array<int, 5>{ r, g, b, p, f };
 	if (last_flash_frame_index > -1
 			&& frame_index - last_flash_frame_index <= 1
-			&& (last_frame_flash.get() == nullptr || *last_frame_flash == flash_array)) {
-		if (last_frame_flash.get() == nullptr) {
-			last_frame_flash = std::make_unique<std::array<int, 5>>(flash_array);
+			&& last_flash_frame_flash == flash_array) {
+		if (!repeating_flash_active) {
+			repeating_flash_active = true;
 			connection.SendPacketAsync<RepeatingFlashPacket>(r, g, b, p, f);
 		}
 	} else {
 		connection.SendPacketAsync<FlashPacket>(r, g, b, p, f);
-		last_frame_flash.reset();
 	}
 	last_flash_frame_index = frame_index;
+	last_flash_frame_flash = flash_array;
 }
 
 void Game_Multiplayer::MainPlayerChangedTransparency(int transparency) {
@@ -804,12 +805,11 @@ void Game_Multiplayer::UpdateServerVariables() {
 
 void Game_Multiplayer::Update() {
 	if (session_active) {
-		if (last_flash_frame_index > -1
-				&& last_frame_flash.get() != nullptr
-				&& frame_index > last_flash_frame_index) {
+		if (repeating_flash_active && frame_index > last_flash_frame_index) {
 			connection.SendPacketAsync<RemoveRepeatingFlashPacket>();
+			repeating_flash_active = false;
 			last_flash_frame_index = -1;
-			last_frame_flash.reset();
+			last_flash_frame_flash.fill(0);
 		}
 
 		++frame_index;

--- a/src/multiplayer/game_multiplayer.h
+++ b/src/multiplayer/game_multiplayer.h
@@ -108,8 +108,9 @@ public:
 	std::vector<std::string> global_sync_picture_prefixes;
 	std::map<int, bool> sync_picture_cache;
 	std::vector<int> sync_battle_anim_ids;
+	bool repeating_flash_active;
 	int last_flash_frame_index{-1};
-	std::unique_ptr<std::array<int, 5>> last_frame_flash;
+	std::array<int, 5> last_flash_frame_flash;
 	std::map<int, std::array<int, 5>> repeating_flashes;
 
 	std::unordered_set<std::string> hrs_set{


### PR DESCRIPTION
Caused by not comparing the previous frame's flash parameters during the repeating flash check.

The issue can be reproduced in maps with parallel flash+wait by using a flashing effect action like the rat form toggle in Collective Unconscious or rainbow/fairy in Yume 2kki. The effect action triggers the repeating flash condition even though the two flashes have different parameters.

Examples of affected maps:
 - Yume 2kki: MAP0160 (Monochrome Street)
 - Yume 2kki: MAP0703 (Florist)
 - Yume 2kki: MAP3594 (Firefly Lake)
 - Collective Unconscious: MAP1407 (Forest)

Regression introduced in a545830a8debcb9c30bda83efb21796fb364982d, an alternative fix would be to revert it.