### PR TITLE
add item count syncing

### DIFF
--- a/src/game_party.cpp
+++ b/src/game_party.cpp
@@ -202,6 +202,7 @@ void Game_Party::AddItem(int item_id, int amount) {
 	}
 
 	int total_items = data.item_counts[idx] + amount;
+	GMI().ItemSet(item_id, total_items);
 
 	if (total_items <= 0) {
 		data.item_ids.erase(data.item_ids.begin() + idx);

--- a/src/game_party.cpp
+++ b/src/game_party.cpp
@@ -201,6 +201,7 @@ void Game_Party::AddItem(int item_id, int amount) {
 	}
 
 	int total_items = data.item_counts[idx] + amount;
+	GMI().ItemSet(item_id, total_items);
 
 	if (total_items <= 0) {
 		data.item_ids.erase(data.item_ids.begin() + idx);

--- a/src/multiplayer/game_multiplayer.cpp
+++ b/src/multiplayer/game_multiplayer.cpp
@@ -213,6 +213,15 @@ void Game_Multiplayer::InitConnection() {
 			sync_action_events.push_back(p.event_id);
 		}
 	});
+	connection.RegisterHandler<SyncItemPacket>("si", [this] (SyncItemPacket& p) {
+		int count = (int) Main_Data::game_party->GetItemCount(p.item_id);
+		if (p.sync_type != -1) {
+			connection.SendPacketAsync<Messages::C2S::SyncItemPacket>(p.item_id, count);
+		}
+		if (p.sync_type >= -1) {
+			sync_items.push_back(p.item_id);
+		}
+	});
 	connection.RegisterHandler<SyncPicturePacket>("sp", [this] (SyncPicturePacket& p) {
 		sync_picture_names.push_back(p.picture_name);
 	});
@@ -535,6 +544,7 @@ void Game_Multiplayer::Initialize() {
 	players.clear();
 	sync_switches.clear();
 	sync_vars.clear();
+	sync_items.clear();
 	sync_events.clear();
 	sync_action_events.clear();
 	sync_picture_names.clear();
@@ -764,6 +774,12 @@ void Game_Multiplayer::SwitchSet(int switch_id, int value_bin) {
 void Game_Multiplayer::VariableSet(int var_id, int value) {
 	if (std::find(sync_vars.begin(), sync_vars.end(), var_id) != sync_vars.end()) {
 		connection.SendPacketAsync<Messages::C2S::SyncVariablePacket>(var_id, value);
+	}
+}
+
+void Game_Multiplayer::ItemSet(int item_id, int count) {
+	if (std::find(sync_items.begin(), sync_items.end(), item_id) != sync_items.end()) {
+		connection.SendPacketAsync<Messages::C2S::SyncItemPacket>(item_id, count);
 	}
 }
 

--- a/src/multiplayer/game_multiplayer.cpp
+++ b/src/multiplayer/game_multiplayer.cpp
@@ -213,6 +213,15 @@ void Game_Multiplayer::InitConnection() {
 			sync_action_events.push_back(p.event_id);
 		}
 	});
+	connection.RegisterHandler<SyncItemPacket>("si", [this] (SyncItemPacket& p) {
+		int count = (int) Main_Data::game_party->GetItemCount(p.item_id);
+		if (p.sync_type != -1) {
+			connection.SendPacketAsync<Messages::C2S::SyncItemPacket>(p.item_id, count);
+		}
+		if (p.sync_type >= -1) {
+			sync_items.push_back(p.item_id);
+		}
+	});
 	connection.RegisterHandler<SyncPicturePacket>("sp", [this] (SyncPicturePacket& p) {
 		sync_picture_names.push_back(p.picture_name);
 	});
@@ -516,6 +525,7 @@ void Game_Multiplayer::Initialize() {
 	players.clear();
 	sync_switches.clear();
 	sync_vars.clear();
+	sync_items.clear();
 	sync_events.clear();
 	sync_action_events.clear();
 	sync_picture_names.clear();
@@ -772,6 +782,12 @@ void Game_Multiplayer::SwitchSet(int switch_id, int value_bin) {
 void Game_Multiplayer::VariableSet(int var_id, int value) {
 	if (std::find(sync_vars.begin(), sync_vars.end(), var_id) != sync_vars.end()) {
 		connection.SendPacketAsync<Messages::C2S::SyncVariablePacket>(var_id, value);
+	}
+}
+
+void Game_Multiplayer::ItemSet(int item_id, int count) {
+	if (std::find(sync_items.begin(), sync_items.end(), item_id) != sync_items.end()) {
+		connection.SendPacketAsync<Messages::C2S::SyncItemPacket>(item_id, count);
 	}
 }
 

--- a/src/multiplayer/game_multiplayer.h
+++ b/src/multiplayer/game_multiplayer.h
@@ -47,6 +47,7 @@ public:
 	void ApplyScreenTone();
 	void SwitchSet(int switch_id, int value);
 	void VariableSet(int var_id, int value);
+	void ItemSet(int item_id, int count);
   void UpdateNBPlayers();
   void UpdateCUTime();
   void UpdateCUWeather();
@@ -101,6 +102,7 @@ public:
 	std::vector<PlayerOther> dc_players;
 	std::vector<int> sync_switches;
 	std::vector<int> sync_vars;
+	std::vector<int> sync_items;
 	std::vector<int> sync_events;
 	std::vector<int> sync_action_events;
 	std::vector<std::string> sync_picture_names; // for badge conditions

--- a/src/multiplayer/game_multiplayer.h
+++ b/src/multiplayer/game_multiplayer.h
@@ -48,6 +48,7 @@ public:
 	void ApplyScreenTone();
 	void SwitchSet(int switch_id, int value);
 	void VariableSet(int var_id, int value);
+	void ItemSet(int item_id, int count);
 
 	struct {
 		bool enable_sounds{ true };
@@ -82,6 +83,7 @@ public:
 	std::vector<PlayerOther> dc_players;
 	std::vector<int> sync_switches;
 	std::vector<int> sync_vars;
+	std::vector<int> sync_items;
 	std::vector<int> sync_events;
 	std::vector<int> sync_action_events;
 	std::vector<std::string> sync_picture_names; // for badge conditions

--- a/src/multiplayer/messages.h
+++ b/src/multiplayer/messages.h
@@ -331,6 +331,15 @@ namespace S2C {
 		const int trigger_type;
 	};
 
+	class SyncItemPacket : public S2CPacket {
+	public:
+		SyncItemPacket(const PL& v)
+			: item_id(Decode<int>(v.at(0))), sync_type(Decode<int>(v.at(1))) {}
+
+		const int item_id;
+		const int sync_type;
+	};
+
 	class SyncPicturePacket : public S2CPacket {
 	public:
 		SyncPicturePacket(const PL& v)
@@ -616,6 +625,15 @@ namespace C2S {
 		int action_bin;
 	};
 
+	class SyncItemPacket : public C2SPacket {
+	public:
+		SyncItemPacket(int _item_id, int _count) : C2SPacket("si"),
+		    item_id(_item_id), count(_count) {}
+		std::string ToBytes() const override { return Build(item_id, count); }
+	protected:
+		int item_id;
+		int count;
+	};
 }
 }
 

--- a/src/multiplayer/messages.h
+++ b/src/multiplayer/messages.h
@@ -345,6 +345,15 @@ namespace S2C {
 		const int trigger_type;
 	};
 
+	class SyncItemPacket : public S2CPacket {
+	public:
+		SyncItemPacket(const PL& v)
+			: item_id(Decode<int>(v.at(0))), sync_type(Decode<int>(v.at(1))) {}
+
+		const int item_id;
+		const int sync_type;
+	};
+
 	class SyncPicturePacket : public S2CPacket {
 	public:
 		SyncPicturePacket(const PL& v)
@@ -638,6 +647,15 @@ namespace C2S {
 		int action_bin;
 	};
 
+	class SyncItemPacket : public C2SPacket {
+	public:
+		SyncItemPacket(int _item_id, int _count) : C2SPacket("si"),
+		    item_id(_item_id), count(_count) {}
+		std::string ToBytes() const override { return Build(item_id, count); }
+	protected:
+		int item_id;
+		int count;
+	};
 }
 }
 


### PR DESCRIPTION
some of the newer games (Love You, FOG) only use items for some things and not permanent switches, which has caused issues with badges being made.

adds item syncing similar to how variables and switches are synced

this has not been tested outside of it compiling.